### PR TITLE
3d regridding

### DIFF
--- a/smmregrid/__init__.py
+++ b/smmregrid/__init__.py
@@ -1,1 +1,1 @@
-from .regrid import Regridder, cdo_generate_weights, regrid, cdo_generate_weights3d
+from .regrid import Regridder, cdo_generate_weights, regrid

--- a/smmregrid/__init__.py
+++ b/smmregrid/__init__.py
@@ -1,1 +1,1 @@
-from .regrid import Regridder, cdo_generate_weights, regrid, cdo_generate_weights3d
+from .regrid import Regridder, cdo_generate_weights, regrid, cdo_generate_weights3d, cdo_generate_weights3d_mp

--- a/smmregrid/__init__.py
+++ b/smmregrid/__init__.py
@@ -1,1 +1,1 @@
-from .regrid import Regridder, cdo_generate_weights, regrid
+from .regrid import Regridder, cdo_generate_weights, regrid, cdo_generate_weights3d

--- a/smmregrid/__init__.py
+++ b/smmregrid/__init__.py
@@ -1,1 +1,1 @@
-from .regrid import Regridder, cdo_generate_weights, regrid, cdo_generate_weights3d, cdo_generate_weights3d_mp
+from .regrid import Regridder, cdo_generate_weights, regrid, cdo_generate_weights3d

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -104,15 +104,19 @@ def cdo_generate_weights(
 
     num_blocks, remainder = divmod(nvert, nproc)
     num_blocks = num_blocks + (0 if remainder == 0 else 1)
-    for i in range(num_blocks):
-        start = i * nproc
-        end = start + nproc
-        end = (nvert if end > nvert else end)
-        print("Block #", i, start, end)
 
-        processes = []
-        for lev in range(start, end):
+    # for i in range(num_blocks):
+    #     start = i * nproc
+    #     end = start + nproc
+    #     end = (nvert if end > nvert else end)
+    #     print("Block #", i, start, end)
 
+    #     processes = []
+    #     for lev in range(start, end):
+
+    blocks = np.array_split(numpy.arange(nvert), num_blocks)
+    for block in blocks:
+        for lev in block:
             print("Generating level:", lev)
             extra2 = [f"-sellevidx,{lev+1}"]
             p = Process(target=worker,

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -77,20 +77,20 @@ def cdo_generate_weights3d_mp(
 
     nvert = sgrid[vert_coord].values.size
     #print(nvert)
-    nvert=3
 
     # for lev in range(0, nvert):
     processes = []
     mgr = Manager()
 
     # dictionaries are shared, so they have to be passed as functions
-    wlist= mgr.list(range(3))
+    wlist= mgr.list(range(nvert))
     
-    for lev, nlev in zip([0, 40, 65], range(3)):
+    #for lev, nlev in zip([0, 40, 65], range(3)):
+    for lev in range(nvert):
         print("Generating level:", lev)
         extra2 = [f"-sellevidx,{lev+1}"]
         p = Process(target=worker,
-                    args=(wlist, nlev, source_grid, target_grid),
+                    args=(wlist, lev, source_grid, target_grid),
                     kwargs=dict(method=method,
                                 extrapolate=extrapolate,
                                 remap_norm=remap_norm,

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -105,15 +105,6 @@ def cdo_generate_weights(
     num_blocks, remainder = divmod(nvert, nproc)
     num_blocks = num_blocks + (0 if remainder == 0 else 1)
 
-    # for i in range(num_blocks):
-    #     start = i * nproc
-    #     end = start + nproc
-    #     end = (nvert if end > nvert else end)
-    #     print("Block #", i, start, end)
-
-    #     processes = []
-    #     for lev in range(start, end):
-
     blocks = np.array_split(numpy.arange(nvert), num_blocks)
     for block in blocks:
         for lev in block:

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -787,7 +787,8 @@ def weightslist_to_3d(ds_list):
     ds0 = ds_list[0].drop(varlist)
     for x, d in zip(ds_list, dim_values):
         nl1 = x.src_address.size
-        xplist = [x[vname].pad(num_links=(0, nl0-nl1),  mode='constant') for vname in varlist ]
+        xplist = [x[vname].pad(num_links=(0, nl0-nl1), mode='constant', constant_values=0)
+                  for vname in varlist ]
         xp = xarray.merge(xplist)
         new_array.append(xp.assign_coords({"lev": d}))
     return xarray.merge([nlda, ds0, xarray.concat(new_array, "lev")])


### PR DESCRIPTION
This is an implementation of 3D regridding.
When `vert_coord` is specified 3D weights can be generated and used.
The weights are stored in a 3d array with the same number of levels as the original data to be regridded. 
It supports parallel processing (we can specify a number of processors `nproc`) for weight generation. This is needed since the process can be extremely time consuming and at the same time memory intensive. 
Regridding itesel, once the weights have been generated, is extremely fast.
