### PR TITLE
Prefix to identify helper index and fix single level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [v0.0.4]
 
+- Allow also single 3D level
+- prefix used to identify helper index coordinate
+
+## [v0.0.4]
+
 - Additional helper coordinate to select correct levels from full 3D weights
 
 ## [v0.0.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [v0.0.4]
+## [v0.0.5]
 
 - Allow also single 3D level
-- prefix used to identify helper index coordinate
+- Prefix used to identify helper index coordinate
 
 ## [v0.0.4]
 

--- a/smmregrid/__init__.py
+++ b/smmregrid/__init__.py
@@ -4,4 +4,4 @@ from .regrid import Regridder, regrid
 from .cdo_weights import cdo_generate_weights
 # from .util import find_vert_coords
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'

--- a/tests/levels_test.py
+++ b/tests/levels_test.py
@@ -19,4 +19,9 @@ def test_plev_gaussian_levels(method):
 def test_nemo_3d_levels(method):
     fff = check_cdo_regrid_levels(os.path.join(INDIR, 'so3d-nemo.nc'), tfile,
                            "lev", [14,15,17], remap_method=method)
-    assert fff is True
+    assert fff is True,  "Multiple levels test failed"
+
+    fff = check_cdo_regrid_levels(os.path.join(INDIR, 'so3d-nemo.nc'), tfile,
+                           "lev", 15, remap_method=method) # single level
+    assert fff is True, "Single level test failed"
+

--- a/tests/levels_test.py
+++ b/tests/levels_test.py
@@ -22,6 +22,6 @@ def test_nemo_3d_levels(method):
     assert fff is True,  "Multiple levels test failed"
 
     fff = check_cdo_regrid_levels(os.path.join(INDIR, 'so3d-nemo.nc'), tfile,
-                           "lev", 15, remap_method=method) # single level
-    assert fff is True, "Single level test failed"
+                           "lev", [15], remap_method=method) # single level
+    assert fff is True, "Single 3D level test failed"
 


### PR DESCRIPTION
Three small adjustments, still related to issue #21 :

1) fix in the case a vertical coordinate of length 1 is passed for a 3D array
2) level_idx now is the **prefix** of the helper coordinates (if multiple ones are found the first one is used)
3) This prefix is now by default "idx_"

