### PR TITLE
Introduce NaN instead of 1e20 after the tensordot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v0.0.6]
+
+- Preserve NaN after interpolation for unmasked fields
+
 ## [v0.0.5]
 
 - Allow also single 3D level

--- a/smmregrid/__init__.py
+++ b/smmregrid/__init__.py
@@ -4,4 +4,4 @@ from .regrid import Regridder, regrid
 from .cdo_weights import cdo_generate_weights
 # from .util import find_vert_coords
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -177,8 +177,8 @@ def apply_weights(source_data, weights, weights_matrix=None, masked=True, space_
         target_dask = dask.array.where(target_mask != 0.0, target_dask, numpy.nan)
     
     # after the tensordot, bring the NaN back in
-    # Use greatear/equal to avoid numerical noise from interpolation.
-    target_dask = xarray.where(target_dask >= 1e20, numpy.nan, target_dask)
+    # Use greater than 1e19 to avoid numerical noise from interpolation.
+    target_dask = xarray.where(target_dask > 1e19, numpy.nan, target_dask)
 
     # reshape the target DataArray
     target_dask = dask.array.reshape(

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -175,6 +175,10 @@ def apply_weights(source_data, weights, weights_matrix=None, masked=True, space_
 
         # apply the mask
         target_dask = dask.array.where(target_mask != 0.0, target_dask, numpy.nan)
+    
+    # after the tensordot, bring the NaN back in
+    # Use greatear/equal to avoid numerical noise from interpolation.
+    target_dask = xarray.where(target_dask >= 1e20, numpy.nan, target_dask)
 
     # reshape the target DataArray
     target_dask = dask.array.reshape(

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -87,3 +87,13 @@ def test_full_plev_gaussian(method):
     fff = check_cdo_regrid(os.path.join(INDIR, 'ua-ecearth.nc'), tfile,
                            remap_method=method, init_method='grids')
     assert fff is True
+
+# test to verify that NaN are preserved
+@pytest.mark.parametrize("method", ['con', 'nn', 'bil'])
+def test_nan_preserve(method): 
+    xfield = xr.open_mfdataset(os.path.join(INDIR, 'tas-ecearth.nc'))
+    xfield['tas'][1,:,:] = np.nan
+    wfield = cdo_generate_weights(indata, tfile, method = method)
+    interpolator = Regridder(weights=wfield)
+    rfield = interpolator.regrid(xfield)
+    assert np.isnan(rfield['tas'][1,:,:]).all().compute()


### PR DESCRIPTION
Fields which are not masked and includes np.nan are filled with 1e20 values and then this values are kept into the resulting array with some unexpected result. This introduces a small fix that bring back the NaN after the tensordot. 