### PR TITLE
Gridtype revisit

### DIFF
--- a/.github/workflows/mambatest.yml
+++ b/.github/workflows/mambatest.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, grid-detector ]
   workflow_dispatch:
   schedule:
     - cron: "0 1 * * 1" #run every Monday night at 1AM UTC

--- a/smmregrid/__init__.py
+++ b/smmregrid/__init__.py
@@ -2,7 +2,7 @@
 
 from .regrid import Regridder, regrid
 from .cdogenerate import cdo_generate_weights, CdoGenerate
-from .gridtype import GridType
+from .gridtype import GridType, DEFAULT_DIMS
 from .gridinspector import GridInspector
 
 

--- a/smmregrid/gridinspector.py
+++ b/smmregrid/gridinspector.py
@@ -109,11 +109,15 @@ class GridInspector():
         # Iterate through grids
         for gridtype in self.grids:
             # Check if any variable in the grid contains 'bnds'
-            if all('bnds' in variable for variable in gridtype.variables):
+            if not gridtype.dims:
+                removed.append(gridtype)
+                self.loggy.info('Removing the grid defined by %s with with no spatial dimensions',
+                                gridtype.dims)
+            elif all('bnds' in variable for variable in gridtype.variables):
                 removed.append(gridtype)  # Add to removed list
                 self.loggy.info('Removing the grid defined by %s with variables containing "bnds"',
                                 gridtype.dims)
-            if all('bounds' in variable for variable in gridtype.variables):
+            elif all('bounds' in variable for variable in gridtype.variables):
                 removed.append(gridtype)  # Add to removed list
                 self.loggy.info('Removing the grid defined by %s with variables containing "bounds"',
                                 gridtype.dims)

--- a/smmregrid/gridinspector.py
+++ b/smmregrid/gridinspector.py
@@ -44,9 +44,9 @@ class GridInspector():
         else:
             raise ValueError('Data supplied is neither xarray Dataset or DataArray')
 
+        # get variables associated to the grid
         for gridtype in self.grids:
             self.identify_variables(gridtype)
-            # gridtype.identify_sizes(self.data)
 
     def _inspect_dataarray_grid(self, data_array):
         """
@@ -126,6 +126,7 @@ class GridInspector():
         """Helper function to process individual variables.
 
         Args:
+            gridtype (GridType): The Gridtype object of originally inspected from the data
             var_data (xr.DataArray): An xarray DataArray containing variable data.
             var_name (str, optional): The name of the variable. If None, uses the name from var_data.
 
@@ -144,7 +145,7 @@ class GridInspector():
         Identify variables in the provided data that match the defined dimensions.
 
         Args:
-            data (xr.Dataset or xr.DataArray): The input data from which to identify variables.
+            gridtype (GridType): The Gridtype object of originally inspected from the data
 
         Raises:
             TypeError: If the input data is neither an xarray Dataset nor DataArray.
@@ -161,6 +162,11 @@ class GridInspector():
             for var in self.data.data_vars:
                 self._identify_variable(gridtype, self.data[var], var)
             gridtype.bounds = self._identify_spatial_bounds(self.data)
+            gridtype.variables = {
+                            key: value
+                            for key, value in gridtype.variables.items()
+                            if key not in set(gridtype.bounds)
+                        }
 
         elif isinstance(self.data, xr.DataArray):
             self._identify_variable(gridtype, self.data)

--- a/smmregrid/gridinspector.py
+++ b/smmregrid/gridinspector.py
@@ -45,7 +45,7 @@ class GridInspector():
             raise ValueError('Data supplied is neither xarray Dataset or DataArray')
 
         for gridtype in self.grids:
-            gridtype.identify_variables(self.data)
+            self.identify_variables(gridtype)
             # gridtype.identify_sizes(self.data)
 
     def _inspect_dataarray_grid(self, data_array):
@@ -109,11 +109,11 @@ class GridInspector():
         # Iterate through grids
         for gridtype in self.grids:
             # Check if any variable in the grid contains 'bnds'
-            if any('bnds' in variable for variable in gridtype.variables):
+            if all('bnds' in variable for variable in gridtype.variables):
                 removed.append(gridtype)  # Add to removed list
                 self.loggy.info('Removing the grid defined by %s with variables containing "bnds"',
                                 gridtype.dims)
-            if any('bounds' in variable for variable in gridtype.variables):
+            if all('bounds' in variable for variable in gridtype.variables):
                 removed.append(gridtype)  # Add to removed list
                 self.loggy.info('Removing the grid defined by %s with variables containing "bounds"',
                                 gridtype.dims)
@@ -121,12 +121,64 @@ class GridInspector():
         for remove in removed:
             self.grids.remove(remove)
 
-    # def get_variable_grids(self):
-    #    """
-    #    Return a dictionary with the variable - grids pairs
-    #    """
-    #    all_grids = {}
-    #    for gridtype in self.grids:
-    #        for variable in gridtype.variables:
-    #            all_grids[variable] = grid_dims
-    #    return all_grids
+
+    def _identify_variable(self, gridtype, var_data, var_name=None):
+        """Helper function to process individual variables.
+
+        Args:
+            var_data (xr.DataArray): An xarray DataArray containing variable data.
+            var_name (str, optional): The name of the variable. If None, uses the name from var_data.
+
+        Updates:
+            self.variables: Updates the variables dictionary with the variable's coordinates.
+        """
+        datagridtype = GridType(var_data.dims, extra_dims=self.extra_dims)
+
+        if datagridtype == gridtype:
+            gridtype.variables[var_name or var_data.name] = {
+                'coords': list(var_data.coords),
+            }
+
+    def identify_variables(self, gridtype):
+        """
+        Identify variables in the provided data that match the defined dimensions.
+
+        Args:
+            data (xr.Dataset or xr.DataArray): The input data from which to identify variables.
+
+        Raises:
+            TypeError: If the input data is neither an xarray Dataset nor DataArray.
+
+        Updates:
+            self.variables: Updates the variables dictionary with identified variables and their coordinates.
+            self.bounds: Updates the bounds list with identified bounds variables from the dataset.
+        """
+
+        if not isinstance(self.data, (xr.Dataset, xr.DataArray)):
+            raise TypeError("Unsupported data type. Must be an xarray Dataset or DataArray.")
+
+        if isinstance(self.data, xr.Dataset):
+            for var in self.data.data_vars:
+                self._identify_variable(gridtype, self.data[var], var)
+            gridtype.bounds = self._identify_spatial_bounds(self.data)
+
+        elif isinstance(self.data, xr.DataArray):
+            self._identify_variable(gridtype, self.data)
+
+    def _identify_spatial_bounds(self, data):
+        """
+        Identify bounds variables in the dataset by checking variable names.
+
+        Args:
+            data (xr.Dataset): An xarray dataset containing data variables.
+
+        Returns:
+            list: A list of bounds variable names identified in the dataset.
+        """
+        bounds_variables = []
+
+        for var in data.data_vars:
+            if (var.endswith('_bnds') or var.endswith('_bounds') or var == 'vertices') and 'time' not in var:
+                bounds_variables.append(var)
+
+        return bounds_variables

--- a/smmregrid/gridtype.py
+++ b/smmregrid/gridtype.py
@@ -99,7 +99,7 @@ class GridType:
             bool: True if both self.dims are equal for both instances, False otherwise.
         """
         if isinstance(other, GridType):
-            return self.dims == other.dims
+            return set(self.dims) == set(other.dims)
         return False
 
     def __hash__(self):

--- a/smmregrid/gridtype.py
+++ b/smmregrid/gridtype.py
@@ -1,5 +1,4 @@
 # GridType class to gather all information about grids with shared dimensions
-import xarray as xr
 
 # default spatial dimensions and vertical coordinates
 DEFAULT_DIMS = {
@@ -54,6 +53,8 @@ class GridType:
         self.dims = (self.horizontal_dims or []) + ([self.vertical_dim] if self.vertical_dim else [])
         self.time_dims = self._identify_dims('time', dims, default_dims)
         self.other_dims = self._identify_other_dims(dims)
+
+        # used by GridInspector
         self.variables = {}
         self.bounds = []
 

--- a/smmregrid/gridtype.py
+++ b/smmregrid/gridtype.py
@@ -26,9 +26,9 @@ class GridType:
                                          way assuming single-gridtype objects. Defaults to None.
 
         Attributes:
-            dims (list): The dimensions defined for the grid.
             horizontal_dims (list): The identified horizontal dimensions from the input.
             vertical_dim (str or None): The identified vertical dimension, if applicable.
+            dims (list): The dimensions defined for the grid. A combination of horizontal and vertical. 
             time_dims (list): The identified time dimensions from the input.
             other_dims (list): The dimensions which are there but are not identified automatically.
             variables (dict): A dictionary holding identified variables and their coordinates.
@@ -46,7 +46,7 @@ class GridType:
         default_dims = self._handle_default_dimensions(extra_dims)
         self.horizontal_dims = self._identify_dims('horizontal', dims, default_dims)
         self.vertical_dim = self._identify_dims('vertical', dims, default_dims)
-        self.dims = (self.horizontal_dims if self.horizontal_dims is not None else []) + ([self.vertical_dim] if self.vertical_dim is not None else [])
+        self.dims = (self.horizontal_dims or []) + ([self.vertical_dim] if self.vertical_dim else [])
         self.time_dims = self._identify_dims('time', dims, default_dims)
         self.other_dims = self._identify_other_dims(dims)
         self.variables = {}
@@ -94,7 +94,7 @@ class GridType:
             bool: True if both horizontal_dims and vertical_dims are equal for both instances, False otherwise.
         """
         if isinstance(other, GridType):
-            return self.horizontal_dims == other.horizontal_dims and self.vertical_dim == other.vertical_dim # and self.other_dims == other.other_dims
+            return self.horizontal_dims == other.horizontal_dims and self.vertical_dim == other.vertical_dim
         return False
 
     def __hash__(self):
@@ -104,7 +104,7 @@ class GridType:
         Returns:
             int: A hash value representing the dimensions of the GridType instance.
         """
-        return hash((self.horizontal_dims, self.vertical_dim)) #, self.other_dims))
+        return hash((self.horizontal_dims, self.vertical_dim))
 
     def _identify_dims(self, axis, dims, default_dims):
         """

--- a/smmregrid/gridtype.py
+++ b/smmregrid/gridtype.py
@@ -43,10 +43,10 @@ class GridType:
         """
 
         # key definitions
-        if extra_dims:
-            for key, value in extra_dims.items():
-                if not isinstance(value, list):
-                    raise ValueError(f'Extra_dims for {key} must be a list!')
+        #if extra_dims:
+        #    for key, value in extra_dims.items():
+        #        if not isinstance(value, list):
+        #            raise ValueError(f'Extra_dims for {key} must be a list!')
 
         default_dims = self._handle_default_dimensions(extra_dims)
         self.horizontal_dims = self._identify_dims('horizontal', dims, default_dims)

--- a/smmregrid/gridtype.py
+++ b/smmregrid/gridtype.py
@@ -91,10 +91,10 @@ class GridType:
             other (GridType): Another GridType instance to compare against.
 
         Returns:
-            bool: True if both horizontal_dims and vertical_dims are equal for both instances, False otherwise.
+            bool: True if both self.dims are equal for both instances, False otherwise.
         """
         if isinstance(other, GridType):
-            return self.horizontal_dims == other.horizontal_dims and self.vertical_dim == other.vertical_dim
+            return self.dims == other.dims
         return False
 
     def __hash__(self):
@@ -104,7 +104,7 @@ class GridType:
         Returns:
             int: A hash value representing the dimensions of the GridType instance.
         """
-        return hash((self.horizontal_dims, self.vertical_dim))
+        return hash(tuple(self.dims))
 
     def _identify_dims(self, axis, dims, default_dims):
         """

--- a/smmregrid/gridtype.py
+++ b/smmregrid/gridtype.py
@@ -43,12 +43,12 @@ class GridType:
         """
 
         # key definitions
-        self.dims = dims
         default_dims = self._handle_default_dimensions(extra_dims)
-        self.horizontal_dims = self._identify_dims('horizontal', default_dims)
-        self.vertical_dim = self._identify_dims('vertical', default_dims)
-        self.time_dims = self._identify_dims('time', default_dims)
-        self.other_dims = self._identify_other_dims()
+        self.horizontal_dims = self._identify_dims('horizontal', dims, default_dims)
+        self.vertical_dim = self._identify_dims('vertical', dims, default_dims)
+        self.dims = (self.horizontal_dims if self.horizontal_dims is not None else []) + ([self.vertical_dim] if self.vertical_dim is not None else [])
+        self.time_dims = self._identify_dims('time', dims, default_dims)
+        self.other_dims = self._identify_other_dims(dims)
         self.variables = {}
         self.bounds = []
 
@@ -91,10 +91,10 @@ class GridType:
             other (GridType): Another GridType instance to compare against.
 
         Returns:
-            bool: True if both horizontal_dims, vertical_dims and other_dims are equal for both instances, False otherwise.
+            bool: True if both horizontal_dims and vertical_dims are equal for both instances, False otherwise.
         """
         if isinstance(other, GridType):
-            return self.horizontal_dims == other.horizontal_dims and self.vertical_dim == other.vertical_dim and self.other_dims == other.other_dims
+            return self.horizontal_dims == other.horizontal_dims and self.vertical_dim == other.vertical_dim # and self.other_dims == other.other_dims
         return False
 
     def __hash__(self):
@@ -104,9 +104,9 @@ class GridType:
         Returns:
             int: A hash value representing the dimensions of the GridType instance.
         """
-        return hash((self.horizontal_dims, self.vertical_dim, self.other_dims))
+        return hash((self.horizontal_dims, self.vertical_dim)) #, self.other_dims))
 
-    def _identify_dims(self, axis, default_dims):
+    def _identify_dims(self, axis, dims, default_dims):
         """
         Identify dimensions along a specified axis.
 
@@ -121,7 +121,7 @@ class GridType:
         Raises:
             ValueError: If more than one vertical dimension is identified.
         """
-        identified_dims = list(set(self.dims).intersection(default_dims[axis]))
+        identified_dims = list(set(dims).intersection(default_dims[axis]))
         if axis == 'vertical':
             if len(identified_dims) > 1:
                 raise ValueError(f'Only one vertical dimension can be processed at the time: check {identified_dims}')
@@ -129,7 +129,7 @@ class GridType:
                 identified_dims = identified_dims[0]  # unlist the single vertical dimension
         return identified_dims if identified_dims else None
 
-    def _identify_other_dims(self):
+    def _identify_other_dims(self, dims):
         """
         Calculate and return the dimensions that are not part of horizontal_dims, vertical_dim, or time_dims.
 
@@ -142,71 +142,7 @@ class GridType:
         time_dims = set(self.time_dims) if self.time_dims else set()
 
         # Return the unused dimensions by subtracting used dimensions from all dimensions
-        return list(set(self.dims) - (horizontal_dims | vertical_dim | time_dims))
+        return list(set(dims) - (horizontal_dims | vertical_dim | time_dims))
+    
 
-    def _identify_spatial_bounds(self, data):
-        """
-        Identify bounds variables in the dataset by checking variable names.
 
-        Args:
-            data (xr.Dataset): An xarray dataset containing data variables.
-
-        Returns:
-            list: A list of bounds variable names identified in the dataset.
-        """
-        bounds_variables = []
-
-        for var in data.data_vars:
-            if (var.endswith('_bnds') or var.endswith('_bounds') or var == 'vertices') and 'time' not in var:
-                bounds_variables.append(var)
-
-        return bounds_variables
-
-    # def identify_sizes(self, data):
-    #    """
-    #    Identify the sizes of the dataset based on the horizontal dimensions.
-    #    """
-    #
-    #    if self.horizontal_dims:
-    #        self.horizontal_sizes  = [data.sizes[x] for x in self.horizontal_dims]
-
-    def _identify_variable(self, var_data, var_name=None):
-        """Helper function to process individual variables.
-
-        Args:
-            var_data (xr.DataArray): An xarray DataArray containing variable data.
-            var_name (str, optional): The name of the variable. If None, uses the name from var_data.
-
-        Updates:
-            self.variables: Updates the variables dictionary with the variable's coordinates.
-        """
-        if set(var_data.dims) == set(self.dims):
-            self.variables[var_name or var_data.name] = {
-                'coords': list(var_data.coords),
-            }
-
-    def identify_variables(self, data):
-        """
-        Identify variables in the provided data that match the defined dimensions.
-
-        Args:
-            data (xr.Dataset or xr.DataArray): The input data from which to identify variables.
-
-        Raises:
-            TypeError: If the input data is neither an xarray Dataset nor DataArray.
-
-        Updates:
-            self.variables: Updates the variables dictionary with identified variables and their coordinates.
-            self.bounds: Updates the bounds list with identified bounds variables from the dataset.
-        """
-
-        if not isinstance(data, (xr.Dataset, xr.DataArray)):
-            raise TypeError("Unsupported data type. Must be an xarray Dataset or DataArray.")
-
-        if isinstance(data, xr.Dataset):
-            for var in data.data_vars:
-                self._identify_variable(data[var], var)
-            self.bounds = self._identify_spatial_bounds(data)
-
-        elif isinstance(data, xr.DataArray):
-            self._identify_variable(data)

--- a/smmregrid/gridtype.py
+++ b/smmregrid/gridtype.py
@@ -43,6 +43,11 @@ class GridType:
         """
 
         # key definitions
+        if extra_dims:
+            for key, value in extra_dims.items():
+                if not isinstance(value, list):
+                    raise ValueError(f'Extra_dims for {key} must be a list!')
+
         default_dims = self._handle_default_dimensions(extra_dims)
         self.horizontal_dims = self._identify_dims('horizontal', dims, default_dims)
         self.vertical_dim = self._identify_dims('vertical', dims, default_dims)

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -234,7 +234,7 @@ class Regridder(object):
         if isinstance(source_data, xarray.Dataset):
 
             # extra call to GridInspector for the raise with multiple grids
-            grid_inspect = GridInspector(source_data, clean=True,
+            grid_inspect = GridInspector(source_data,
                                      extra_dims=self.extra_dims,
                                      loglevel=self.loglevel)
             datagrids = grid_inspect.get_grid_info()
@@ -271,7 +271,7 @@ class Regridder(object):
         """
         
         self.loggy.debug('Getting GridType from source_data')
-        grid_inspect = GridInspector(source_data, clean=True,
+        grid_inspect = GridInspector(source_data,
                                      extra_dims=self.extra_dims,
                                      loglevel=self.loglevel)
         datagrids = grid_inspect.get_grid_info()

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -233,8 +233,6 @@ class Regridder(object):
         # apply the regridder on each DataArray
         if isinstance(source_data, xarray.Dataset):
 
-            out = source_data.map(self.regrid_array, keep_attrs=False)
-
             # extra call to GridInspector for the raise with multiple grids
             grid_inspect = GridInspector(source_data, clean=True,
                                      extra_dims=self.extra_dims,
@@ -242,6 +240,9 @@ class Regridder(object):
             datagrids = grid_inspect.get_grid_info()
             if len(datagrids)>1 and self.init_mode == 'weights':
                 raise ValueError(f'Cannot process data with {len(datagrids)} GridType initializing from weights')
+
+            # map on multiple dataarray
+            out = source_data.map(self.regrid_array, keep_attrs=False)
 
             # clean from degenerated variables
             degen_vars = [var for var in out.data_vars if out[var].dims == ()]
@@ -268,7 +269,7 @@ class Regridder(object):
         Raises:
             ValueError: If the input data does not match expected dimensions.
         """
-
+        
         self.loggy.debug('Getting GridType from source_data')
         grid_inspect = GridInspector(source_data, clean=True,
                                      extra_dims=self.extra_dims,

--- a/tests/gridinspector_test.py
+++ b/tests/gridinspector_test.py
@@ -1,0 +1,25 @@
+"""Set of basic tests for smmregrid weights"""
+
+import os
+import pytest
+import xarray
+from smmregrid import GridInspector
+
+
+INDIR = 'tests/data'
+
+@pytest.mark.parametrize("file,ngrids,firstdims, variables", [
+    ("2t-era5.nc", 1, ["lon", "lat"], ['2t']),
+    ("mix-cesm.nc", 1, ["lon", "lat"], ['hfss', 'hfls', 'rlds', 'rlus']),
+    ("so3d-nemo.nc", 1, ["i", "j", "lev"], ['so']),
+    ("ua-so_mix_ecearth.nc", 2, ["lon", "lat"], ['ua']),
+    ("temp3d-fesom.nc", 1, ['nod2', 'nz1'], ['temp']),
+    ])
+def test_basic_gridinspector(file, ngrids, firstdims, variables):
+    """test for GridInspector"""
+    filename = os.path.join('tests/data', file)
+    xfield = xarray.open_mfdataset(filename)
+    grids = GridInspector(xfield, loglevel='debug').get_grid_info()
+    assert len(grids) == ngrids
+    assert sorted(grids[0].dims) == sorted(firstdims)
+    assert list(grids[0].variables.keys()) == variables

--- a/tests/gridinspector_test.py
+++ b/tests/gridinspector_test.py
@@ -1,4 +1,4 @@
-"""Set of basic tests for smmregrid weights"""
+"""Set of basic tests for smmregrid gridinspector"""
 
 import os
 import pytest

--- a/tests/gridinspector_test.py
+++ b/tests/gridinspector_test.py
@@ -21,5 +21,5 @@ def test_basic_gridinspector(file, ngrids, firstdims, variables):
     xfield = xarray.open_mfdataset(filename)
     grids = GridInspector(xfield, loglevel='debug').get_grid_info()
     assert len(grids) == ngrids
-    assert sorted(grids[0].dims) == sorted(firstdims)
-    assert list(grids[0].variables.keys()) == variables
+    assert set(grids[0].dims) == set(firstdims)
+    assert set(grids[0].variables.keys()) == set(variables)

--- a/tests/gridtype_test.py
+++ b/tests/gridtype_test.py
@@ -7,14 +7,15 @@ from smmregrid import GridType
     (['lon','lat'], ['lon', 'lat'], []),
     (['lon','lat', 'lev', 'time'], ['lon', 'lat', 'lev'], []),
     (['i', 'k'], ['i'], ['k']),
-    (['pix', 'time', 'papera'], ['pix'], ['papera'])
+    (['pix', 'time', 'papera'], ['pix'], ['papera']),
+    (['time', 'papera'], [], ['papera'])
 
     ])
 def test_gridtype(definition, dims, other):
     """Basic gridtype investigation"""
     grid = GridType(dims=definition)
-    assert sorted(grid.dims) == sorted(dims)
-    assert grid.other_dims == other
+    assert set(grid.dims) == set(dims)
+    assert set(grid.other_dims) == set(other)
 
 def test_difference():
     """Test equality for gridtypes"""

--- a/tests/gridtype_test.py
+++ b/tests/gridtype_test.py
@@ -1,0 +1,40 @@
+"""Set of basic tests for smmregrid weights"""
+
+import pytest
+from smmregrid import GridType
+
+@pytest.mark.parametrize("definition,dims,other", [
+    (['lon','lat'], ['lon', 'lat'], []),
+    (['lon','lat', 'lev', 'time'], ['lon', 'lat', 'lev'], []),
+    (['i', 'k'], ['i'], ['k']),
+    (['pix', 'time', 'papera'], ['pix'], ['papera'])
+
+    ])
+def test_gridtype(definition, dims, other):
+    """Basic gridtype investigation"""
+    grid = GridType(dims=definition)
+    assert sorted(grid.dims) == sorted(dims)
+    assert grid.other_dims == other
+
+def test_difference():
+    """Test equality for gridtypes"""
+    grid1 = GridType(dims=['lon', 'lat'])
+    grid2 = GridType(dims=['i', 'j'])
+    grid3 = GridType(dims=['lon', 'lat', 'time', 'plev'])
+    assert grid1 != grid2
+    assert grid1 == grid3
+
+def test_multiple_vertical():
+    """Test multiple vertical"""
+    with pytest.raises(ValueError):
+        GridType(dims=['lon', 'lat', 'lev', 'nz1'])
+
+def test_gridtype_extradims():
+    """Test for extradimensions"""
+    with pytest.raises(ValueError):
+        GridType(dims=["lon", "lat", "ciccio"],
+                 extra_dims = {'horizontal': "nonnapaper"})
+
+    grid = GridType(dims=["lon", "lat", "ciccio"],
+                    extra_dims = {'vertical': ["ciccio"]})
+    assert grid.vertical_dim == "ciccio"

--- a/tests/gridtype_test.py
+++ b/tests/gridtype_test.py
@@ -31,9 +31,9 @@ def test_multiple_vertical():
 
 def test_gridtype_extradims():
     """Test for extradimensions"""
-    with pytest.raises(ValueError):
-        GridType(dims=["lon", "lat", "ciccio"],
-                 extra_dims = {'horizontal': "nonnapaper"})
+    #with pytest.raises(ValueError):
+    #    GridType(dims=["lon", "lat", "ciccio"],
+    #             extra_dims = {'horizontal': "nonnapaper"})
 
     grid = GridType(dims=["lon", "lat", "ciccio"],
                     extra_dims = {'vertical': ["ciccio"]})

--- a/tests/multigrid_test.py
+++ b/tests/multigrid_test.py
@@ -16,8 +16,8 @@ def test_multi_grid_inspection():
     data = xr.open_dataset(ifile)
     regridded = regrid.regrid(data)
     assert len(regrid.grids) == 2
-    assert vars(regrid.grids[1])['dims'] == ('time', 'lev', 'j', 'i')
-    assert vars(regrid.grids[0])['dims'] == ('time', 'plev', 'lat', 'lon')
+    assert vars(regrid.grids[1])['dims'] == ('lev', 'j', 'i')
+    assert vars(regrid.grids[0])['dims'] == ('plev', 'lat', 'lon')
     assert regridded['ua'].shape == (2, 3, 90, 180)
     assert regridded['so'].shape == (2, 3, 90, 180)
 

--- a/tests/multigrid_test.py
+++ b/tests/multigrid_test.py
@@ -16,8 +16,8 @@ def test_multi_grid_inspection():
     data = xr.open_dataset(ifile)
     regridded = regrid.regrid(data)
     assert len(regrid.grids) == 2
-    assert vars(regrid.grids[1])['dims'] == ('lev', 'j', 'i')
-    assert vars(regrid.grids[0])['dims'] == ('plev', 'lat', 'lon')
+    assert vars(regrid.grids[1])['dims'] == ['lev', 'j', 'i']
+    assert vars(regrid.grids[0])['dims'] == ['plev', 'lat', 'lon']
     assert regridded['ua'].shape == (2, 3, 90, 180)
     assert regridded['so'].shape == (2, 3, 90, 180)
 

--- a/tests/multigrid_test.py
+++ b/tests/multigrid_test.py
@@ -16,8 +16,8 @@ def test_multi_grid_inspection():
     data = xr.open_dataset(ifile)
     regridded = regrid.regrid(data)
     assert len(regrid.grids) == 2
-    assert vars(regrid.grids[1])['dims'] == ['lev', 'j', 'i']
-    assert vars(regrid.grids[0])['dims'] == ['plev', 'lat', 'lon']
+    assert sorted(vars(regrid.grids[1])['dims']) == sorted(['lev', 'j', 'i'])
+    assert sorted(vars(regrid.grids[0])['dims']) == sorted(['plev', 'lat', 'lon'])
     assert regridded['ua'].shape == (2, 3, 90, 180)
     assert regridded['so'].shape == (2, 3, 90, 180)
 


### PR DESCRIPTION
I found a tricky bug which I am trying to work on here. The problem is that GridType object have an equality based on dimensions, horizontal+vertical+extra. However, we do not need this while we should always consider that horizontal and vertical case only. 

However, the issue is that variable identification should not a feature of GridType but rather of GridInspector. I am trying to revisit this here but it will require a bit of work. I assume we could merge the current refactoring and then further dig with this. 