### PR TITLE
Automatic mask evaluation

### DIFF
--- a/smmregrid/util.py
+++ b/smmregrid/util.py
@@ -2,6 +2,7 @@
 
 import re
 import os
+import numpy
 import warnings
 import xarray
 


### PR DESCRIPTION
This PR serves for a long term project which targets the possible removal of the dependency on the vertical coordinate of smmregrid. 

The idea is to build on the new feature of CDO which allows for a `map3d=True` which will create a weights for each level when the mask is changing. This meanns that are obtained less weights than available levels. 

It is in principle possible to compute the amount of NaN in the src mask of the weights and to directly compare with the ones in the data.

Then weights selection for each level can be done - still need to be investigated if this can be done lazily - so that the right matching is based on the amount of NaN rather than the level idx