### PR TITLE
Remove bounds when running GridInspector

### DIFF
--- a/smmregrid/gridinspector.py
+++ b/smmregrid/gridinspector.py
@@ -28,7 +28,6 @@ class GridInspector():
         self.loglevel = loglevel
         self.extra_dims = extra_dims
         self.data = self._open_data(data)
-        self.data = data
         self.cdo_weights = cdo_weights
         self.clean = clean
         self.grids = []  # List to hold all grids info
@@ -40,6 +39,7 @@ class GridInspector():
         Open the data from a file path if it is a string and the file exists
         """
         if isinstance(data, (xr.Dataset, xr.DataArray)):
+            self.loggy.info('Data is already an xarray Dataset or DataArray')
             return data
         if isinstance(data, str):
             if os.path.exists(data):

--- a/smmregrid/gridinspector.py
+++ b/smmregrid/gridinspector.py
@@ -55,10 +55,9 @@ class GridInspector():
 
         if isinstance(self.data, xr.Dataset):
             self.data.map(self._inspect_dataarray_grid, keep_attrs=False)
-        elif isinstance(self.data, xr.DataArray):
+        if isinstance(self.data, xr.DataArray):
             self._inspect_dataarray_grid(self.data)
-        else:
-            raise TypeError('Data supplied is neither xarray Dataset or DataArray')
+
 
         # get variables associated to the grid
         for gridtype in self.grids:
@@ -184,9 +183,6 @@ class GridInspector():
             self.variables: Updates the variables dictionary with identified variables and their coordinates.
             self.bounds: Updates the bounds list with identified bounds variables from the dataset.
         """
-
-        if not isinstance(self.data, (xr.Dataset, xr.DataArray)):
-            raise TypeError("Unsupported data type. Must be an xarray Dataset or DataArray.")
 
         if isinstance(self.data, xr.Dataset):
             for var in self.data.data_vars:

--- a/tests/gridinspector_test.py
+++ b/tests/gridinspector_test.py
@@ -17,9 +17,11 @@ INDIR = 'tests/data'
     ])
 def test_basic_gridinspector(file, ngrids, firstdims, variables, kind):
     """test for GridInspector"""
-    filename = os.path.join('tests/data', file)
-    xfield = xarray.open_mfdataset(filename)
-    grids = GridInspector(xfield, loglevel='debug').get_grid_info()
+    xfield = os.path.join('tests/data', file)
+    if file == '2t-era5.nc':
+        xfield = xarray.open_dataset(xfield)
+
+    grids = GridInspector(xfield, loglevel='debug').get_gridtype()
     assert len(grids) == ngrids
     assert set(grids[0].dims) == set(firstdims)
     assert set(grids[0].variables.keys()) == set(variables)

--- a/tests/gridinspector_test.py
+++ b/tests/gridinspector_test.py
@@ -18,11 +18,35 @@ INDIR = 'tests/data'
 def test_basic_gridinspector(file, ngrids, firstdims, variables, kind):
     """test for GridInspector"""
     xfield = os.path.join('tests/data', file)
-    if file == '2t-era5.nc':
-        xfield = xarray.open_dataset(xfield)
-
+    xfield = xarray.open_dataset(xfield)
     grids = GridInspector(xfield, loglevel='debug').get_gridtype()
     assert len(grids) == ngrids
     assert set(grids[0].dims) == set(firstdims)
     assert set(grids[0].variables.keys()) == set(variables)
     assert grids[0].kind == kind
+
+def test_basic_gridinspector_raise():
+    """test for GridInspector raise"""
+    with pytest.raises(TypeError):
+        GridInspector(24)
+    with pytest.raises(FileNotFoundError):
+        GridInspector('not_a_file.nc')
+
+def test_basic_gridinspector_dataarray():
+    """test for GridInspector with a DataArray"""
+    xfield = os.path.join('tests/data', '2t-era5.nc')
+    xfield = xarray.open_dataset(xfield)['2t']
+    grids = GridInspector(xfield, loglevel='debug').get_gridtype()
+    assert len(grids) == 1
+    assert set(grids[0].dims) == set(['lon', 'lat'])
+    assert set(grids[0].variables.keys()) == set(['2t'])
+    assert grids[0].kind == 'Regular'
+
+def test_get_gridtype_attr():
+    """test for GridInspector get_gridtype_attr"""
+    xfield = os.path.join('tests/data', '2t-era5.nc')
+    gridinspect = GridInspector(xfield, loglevel='debug')
+    grids = gridinspect.get_gridtype()
+    assert set(gridinspect.get_gridtype_attr(grids, 'dims')) == set(['lon', 'lat'])
+    assert gridinspect.get_gridtype_attr(grids, 'variables') == ['2t']
+    assert gridinspect.get_gridtype_attr(grids, 'kind') == ['Regular']


### PR DESCRIPTION
As per title, this will focus running the GridType detection only on real variables and not on bounds