### PR TITLE
remove map to address tests

### DIFF
--- a/smmregrid/gridinspector.py
+++ b/smmregrid/gridinspector.py
@@ -58,7 +58,9 @@ class GridInspector():
         """
 
         if isinstance(self.data, xr.Dataset):
-            self.data.map(self._inspect_dataarray_grid, keep_attrs=False)
+            #self.data.map(self._inspect_dataarray_grid, keep_attrs=False)
+            for var in self.data.data_vars:
+                self._inspect_dataarray_grid(self.data[var])
         if isinstance(self.data, xr.DataArray):
             self._inspect_dataarray_grid(self.data)
 

--- a/smmregrid/regrid.py
+++ b/smmregrid/regrid.py
@@ -261,7 +261,11 @@ class Regridder(object):
                 raise ValueError(f'Cannot process data with {len(datagrids)} GridType initializing from weights')
 
             # map on multiple dataarray
-            out = source_data.map(self.regrid_array, keep_attrs=False)
+            #out = source_data.map(self.regrid_array, keep_attrs=True)
+            out_vars = {}
+            for var in source_data.data_vars:
+                out_vars[var] = self.regrid_array(source_data[var])
+            out = xarray.Dataset(out_vars, attrs=source_data.attrs)
 
             # clean from degenerated variables
             degen_vars = [var for var in out.data_vars if out[var].dims == ()]


### PR DESCRIPTION
A new release of xarray, `2025.09.1`, changed some propagation method of attributes of coordinates with `map` method. the current method we use inside smmregrid, at both `GridInspector` and `regrid` level is not compatible so I had to temporarily disable the `map`.

We need to understand if this is something related to a misuse from our side or a bug on xarray side.